### PR TITLE
Check that dock exists on platform

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,7 +28,9 @@ if (process.platform === "win32") {
 }
 
 function createWindow() {
-  app.dock.setIcon(path.join(__dirname, "icons/png/128x128.png"))
+  if (app.dock) {
+    app.dock.setIcon(path.join(__dirname, "icons/png/128x128.png"))
+  }
   // Create the browser window.
   mainWindow = new BrowserWindow({
     titleBarStyle: "hidden",


### PR DESCRIPTION
Hey Sara! I tried running this on Ubuntu 18.04. `app.dock` is Mac specific so it's undefined when running on Linux:

<img width="574" alt="Screen Shot 2020-01-02 at 12 22 25 pm" src="https://user-images.githubusercontent.com/21051488/71649531-5c2dca00-2d5b-11ea-9786-e562e5e359b2.png">

I've added a quick check to make sure it exists. With this change the app runs well on Ubuntu 👍 

<img width="953" alt="Screen Shot 2020-01-02 at 2 03 42 pm" src="https://user-images.githubusercontent.com/21051488/71651392-d9ac0700-2d68-11ea-9c95-d798cbe1169a.png">